### PR TITLE
Fix 'TypeError: write() argument must be str, not bytes'

### DIFF
--- a/udemy-dl.py
+++ b/udemy-dl.py
@@ -420,7 +420,7 @@ class UdemyDownload:
                         if os.path.isfile(filename):
                             print (fc + sd + "[" + fm + sb + "*" + fc + sd + "] : " + fg + sd + "Lecture : '%s' " % (lecture_name) + fy + sb + "(already downloaded).")
                         else:
-                            with open(filename, 'w') as f:
+                            with open(filename, 'wb') as f:
                                 f.write(html)
                             f.close
                             print (fc + sd + "[" + fm + sb + "+" + fc + sd + "] : " + fg + sd + "Lecture : (%s) " % (lecture_name) + fw + sb + "(saved).")


### PR DESCRIPTION
Signed-off-by: kizbitz <jerry.baker@docker.com>

Fixes the following:

```
Traceback (most recent call last):
  File "udemy-dl.py", line 894, in <module>
    main()
  File "udemy-dl.py", line 810, in main
    udemy.ExtractAndDownload(path=outto)
  File "udemy-dl.py", line 425, in ExtractAndDownload
    f.write(html)
TypeError: write() argument must be str, not bytes
```