### PR TITLE
Remove windows reserved characters from the title

### DIFF
--- a/udemy/_sanitize.py
+++ b/udemy/_sanitize.py
@@ -49,6 +49,16 @@ def sanitize_title(title):
                 '220'  : 'U',
                 '168U' : 'U',
                 '209'  : 'N',
+	# Remove Windows Reserved Characters
+                '<': '',
+                '>': '',
+                ':': '',
+                '"': '',
+                '\\': '',
+                '/': '',
+                '|': '',
+                '?': '',
+                '*': '',
     }
     _temp   = ''.join([str(ord(i)) if ord(i) > 128 else i for i in title])
     for _ascii,_char in _locale.items():


### PR DESCRIPTION
When using udemy-dl in Linux Bash on Windows 10, script is unable to create file if there is a [reserved character](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx) in file name and fails with an error.

Since these characters don't have much information value the simplest solution is to remove them from the title.