### PR TITLE
Cookie request header could be in mixed case

### DIFF
--- a/udemy/_extract.py
+++ b/udemy/_extract.py
@@ -76,7 +76,7 @@ class Udemy(ProgressBar):
         cookies = {}
         cookie_parser = ParseCookie()
         try:
-            cookie_string = re.search(r'Cookie:\s*(.+)\n', raw_cookies).group(1)
+            cookie_string = re.search(r'Cookie:\s*(.+)\n', raw_cookies, flags=re.IGNORECASE).group(1)
         except:
             sys.stdout.write(fc + sd + "[" + fr + sb + "-" + fc + sd + "] : " + fr + sb + "Cookies error, Request Headers is required.\n")
             sys.stdout.write(fc + sd + "[" + fm + sb + "i" + fc + sd + "] : " + fg + sb + "Copy Request Headers for single request to a file, while you are logged in.\n")


### PR DESCRIPTION
Google Chrome "cookie" is lower case and the re.search doesn't find it.