### PR TITLE
Fix KeyError if a chapter has no lectures

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,5 +10,6 @@
  - @NoMoreUsernamesAvailable (Feature request for Umlauts (unicode based characters) in filenames)
  - @RuthlessRuler (Requested to add support Aria2c downloader)
  - @alfari16 (Download from specific chapter)
+ - @arsenico13 (fixed KeyError if a chapter has no lectures)
 
-> Thanks to all other contributors if i missed any one.   
+> Thanks to all other contributors if i missed any one.

--- a/udemy/_internal.py
+++ b/udemy/_internal.py
@@ -80,7 +80,7 @@ class InternUdemyChapter(UdemyChapters):
         self._chapter_title     = chapter['chapter_title']
         self._unsafe_title      = chapter['unsafe_chapter']
         self._chapter_index     = chapter['chapter_index']
-        self._lectures_count    = chapter['lectures_count']
+        self._lectures_count    = chapter.get('lectures_count', 0)
         self._lectures          = [InternUdemyLecture(z) for z in chapter['lectures']]
 
 


### PR DESCRIPTION
If a course had a chapter whith no lectures in it, you'd get `KeyError: 'lectures_count'`.
(I had this problem with one of the courses I bought).