### PR TITLE
Employ 'ignore' error handling scheme when reading WebVTT subtitles.

### DIFF
--- a/udemy/_vtt2srt.py
+++ b/udemy/_vtt2srt.py
@@ -39,7 +39,8 @@ class WebVtt2Srt(object):
 
     def _vttcontents(self, fname):
         try:
-            f = codecs.open(filename=fname, encoding='utf-8')
+            # in case of a non-UTF-8 file content the 'ignore' strategy comes into play
+            f = codecs.open(filename=fname, encoding='utf-8', errors='ignore')
         except Exception as e:
             return {'status' : 'False', 'msg' : 'failed to open file : file not found ..'}
         content = [line for line in (l.strip() for l in f)]


### PR DESCRIPTION
The default 'strict' one had issues when reading subtitles in
some languages (Thai, for example). This way, the non-UTF-8 text
will be retained and the process continued.