### PR TITLE
Remove client_id

### DIFF
--- a/udemy/_auth.py
+++ b/udemy/_auth.py
@@ -69,17 +69,16 @@ class UdemyAuth(object):
                 })
             return login_form
 
-    def authenticate(self, access_token='', client_id=''):
-        if not access_token and not client_id:
+    def authenticate(self, access_token=''):
+        if not access_token:
             data = {'email' : self.username, 'password' : self.password}
             auth_response = self._session._post(LOGIN_URL, data=data)
             auth_cookies, auth_response = auth_response.cookies, auth_response.json()
             
             access_token = auth_response.get('access_token', '')
-            client_id = auth_cookies.get('client_id', '')
         
         if access_token:
-            self._session._set_auth_headers(access_token=access_token, client_id=client_id)
+            self._session._set_auth_headers(access_token=access_token)
             return self._session
         else:
             self._session._set_auth_headers()

--- a/udemy/_extract.py
+++ b/udemy/_extract.py
@@ -78,14 +78,12 @@ class Udemy(ProgressBar):
     def _extract_cookie_string(self, raw_cookies):
         cookies = {}
         try:
-            client_id = re.search(r'(?i)(?:client_id=(?P<client_id>\w+))', raw_cookies)
             access_token = re.search(r'(?i)(?:access_token=(?P<access_token>\w+))', raw_cookies)
         except:
             sys.stdout.write(fc + sd + "[" + fr + sb + "-" + fc + sd + "] : " + fr + sb + "Cookies error, Request Headers is required.\n")
             sys.stdout.write(fc + sd + "[" + fm + sb + "i" + fc + sd + "] : " + fg + sb + "Copy Request Headers for single request to a file, while you are logged in.\n")
             sys.exit(0)
-        cookies.update({'client_id': client_id.group('client_id'),
-                        'access_token': access_token.group('access_token')})
+        cookies.update({'access_token': access_token.group('access_token')})
         return cookies
 
     def _sanitize(self, unsafetext):
@@ -99,10 +97,9 @@ class Udemy(ProgressBar):
         if cookies:
             self._cookies = self._extract_cookie_string(raw_cookies=cookies)
             access_token = self._cookies.get('access_token')
-            client_id = self._cookies.get('client_id')
             time.sleep(0.3)
             auth = UdemyAuth()
-            self._session = auth.authenticate(access_token=access_token, client_id=client_id)
+            self._session = auth.authenticate(access_token=access_token)
             self._session._session.cookies.update(self._cookies)
         if self._session is not None:
             return {'login' : 'successful'}

--- a/udemy/_session.py
+++ b/udemy/_session.py
@@ -39,7 +39,7 @@ class Session(object):
         self._headers = HEADERS
         self._session = requests.sessions.Session()
 
-    def _set_auth_headers(self, access_token='', client_id=''):
+    def _set_auth_headers(self, access_token=''):
         self._headers['Authorization'] = "Bearer {}".format(access_token)
         self._headers['X-Udemy-Authorization'] = "Bearer {}".format(access_token)
 


### PR DESCRIPTION
Basically, right now, udemy-dl doesn't need or use **client_id** from cookie at all.

It extracts **client_id** from cookie but when it makes a GET or a POST request inside _session.py, it only uses **access_token** and everything is working fine.

![a](https://user-images.githubusercontent.com/48912654/55271777-6ee61080-52aa-11e9-984a-52aa4f601be7.png)

And to try that out, i make a cookie.txt with only this line **access_token=abcd1234** and when i login or download the course, i have no problem.

![b](https://user-images.githubusercontent.com/48912654/55271786-87eec180-52aa-11e9-971c-25744e370ac8.png)
