### PR TITLE
Fix 'FileNotFoundError' is not defined + missing txt file on Windows

### DIFF
--- a/udemy/_shared.py
+++ b/udemy/_shared.py
@@ -513,6 +513,8 @@ class UdemyLectureAssets(object):
 
         try:
             filename += '.txt' if not unsafe else u'.txt'
+            if os.name == 'nt':
+                filename = '\\\\?\\' + filename
             f = codecs.open(filename, 'a', encoding='utf-8', errors='ignore')
             data = '{}\n'.format(self.url) if not unsafe else u'{}\n'.format(self.url)
             f.write(data)


### PR DESCRIPTION
#372

![b](https://user-images.githubusercontent.com/48912654/56563262-bce4f000-659a-11e9-9ea7-43d309c5e1ec.png)

This error says: "I'm writing a txt file to your local machine but the path to your txt file is too long, and Windows doesn't like that"

Windows historically has limited path lengths to 260 characters. This meant that paths longer than this would not resolve and errors would result.

I think this happen mostly because you are using Python 2.

In Python 2, you got an error, that's fine.
But in Python 3 (without "Disable path length limit" when install Python), you lost this file and udemy-dl acts like everything is normal.

![a](https://user-images.githubusercontent.com/48912654/56563145-7becdb80-659a-11e9-9c92-df1626c5e8ad.png)

<b>Note</b>: the txt file is now saved but you can't open with notepad on Windows (that's Windows problem with long path)

But you can open it with Sublime Text, Pycharm
Or move your file to Desktop and open it (because it's the shortest path you can think of)