### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/udemy/_vtt2srt.py
+++ b/udemy/_vtt2srt.py
@@ -39,7 +39,7 @@ class WebVtt2Srt(object):
 
     def _vttcontents(self, fname):
         try:
-            f = codecs.open(filename=fname, encoding='utf-8')
+            f = codecs.open(filename=fname, encoding='utf-8', errors='ignore')
         except Exception as e:
             return {'status' : 'False', 'msg' : 'failed to open file : file not found ..'}
         content = [line for line in (l.strip() for l in f)]


### PR DESCRIPTION
#385 

0x92 is a smart quote(’) of Windows-1252. vtt isn't using it in timestamp or line count so it's in content. i use this fix because i see you already put error ignore all over places in your code.