### PR TITLE
Fix missing file on Windows

### DIFF
--- a/udemy/_shared.py
+++ b/udemy/_shared.py
@@ -513,6 +513,8 @@ class UdemyLectureAssets(object):
 
         try:
             filename += '.txt' if not unsafe else u'.txt'
+            if os.name == 'nt' and len(filename) > 259:
+                filename = '\\\\?\\' + filename
             f = codecs.open(filename, 'a', encoding='utf-8', errors='ignore')
             data = '{}\n'.format(self.url) if not unsafe else u'{}\n'.format(self.url)
             f.write(data)


### PR DESCRIPTION
course : https://www.udemy.com/java-the-complete-java-developer-course/

problem occurs on python 2 and ( python 3 without disable path length option )

some path too long: 280, 290, ... characters but windows only allow < 260