### PR TITLE
Fix duplicate external links

### DIFF
--- a/udemy/_shared.py
+++ b/udemy/_shared.py
@@ -513,7 +513,7 @@ class UdemyLectureAssets(object):
 
         try:
             filename += '.txt' if not unsafe else u'.txt'
-            f = codecs.open(filename, 'a', encoding='utf-8', errors='ignore')
+            f = codecs.open(filename, 'w', encoding='utf-8', errors='ignore')
             data = '{}\n'.format(self.url) if not unsafe else u'{}\n'.format(self.url)
             f.write(data)
         except (OSError, Exception, UnicodeDecodeError) as e:


### PR DESCRIPTION
on slow network, big course, maybe a person have to download a course multi times.

external link inside txt files will be duplicate that much times, download 20 times will have the same 20 links inside

external link is just a link (like an url inside html 'a' tag), it can't be 2 or 3 or ...