### PR TITLE
Download failed for certain courses, for example with /draft/:id/ in the URL)

### DIFF
--- a/udemy-dl.py
+++ b/udemy-dl.py
@@ -940,7 +940,6 @@ def main():
     if options.cookies:
         f_in = open(options.cookies)
         cookies = '\n'.join([line for line in (l.strip() for l in f_in) if line])
-        print(cookies)
         f_in.close()
         udemy = Udemy(url=options.course, cookies=cookies)
         if options.list and not options.save:

--- a/udemy-dl.py
+++ b/udemy-dl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import os
@@ -940,6 +940,7 @@ def main():
     if options.cookies:
         f_in = open(options.cookies)
         cookies = '\n'.join([line for line in (l.strip() for l in f_in) if line])
+        print(cookies)
         f_in.close()
         udemy = Udemy(url=options.course, cookies=cookies)
         if options.list and not options.save:

--- a/udemy/_extract.py
+++ b/udemy/_extract.py
@@ -174,14 +174,12 @@ class Udemy(ProgressBar):
         return courses_lists
 
     def __extract_course(self, response, course_name):
-        _temp = {}
-        if response:
-            for entry in response:
-                course_id = entry.get('id')
-                published_title = entry.get('published_title')
-                if course_name in (published_title, course_id):
-                    _temp = entry
-        return _temp
+        for entry in response:
+            if course_name == str(entry.get('id')) or course_name == \
+                    entry.get('published_title'):
+                return entry
+
+        return {}
 
     def _extract_course_info(self, url):
         portal_name, course_name = self._course_name(url)


### PR DESCRIPTION
Draft courses like the one below 
./udemy-dl.py https://www.udemy.com/draft/368340/learn/ -k cookies.txt

would fail to download with "[-] : Downloading course information, course id not found .. (failed)". The issue lied in the comparison made in the _extract_course() method.

Also, the shebang should get the correct Python interpreter from the user environment not a hard-coded path. I typically run Python scripts in a virtualenv and the original code would fail.