### PR TITLE
changed subtitle file naming

### DIFF
--- a/udemy/_shared.py
+++ b/udemy/_shared.py
@@ -656,13 +656,13 @@ class UdemyLectureSubtitles(Downloader):
     def _generate_filename(self):
         ok = re.compile(r'[^\\/:*?"<>|]')
         filename = "".join(x if ok.match(x) else "_" for x in self.title)
-        filename += "-{}.{}".format(self.language, self.extension)
+        filename += ".{}.{}".format(self.language, self.extension)
         return filename
 
     def _generate_unsafe_filename(self):
         ok = re.compile(r'[^\\/:*?"<>|]')
         filename = "".join(x if ok.match(x) else "_" for x in self.unsafe_title)
-        filename += "-{}.{}".format(self.language, self.extension)
+        filename += ".{}.{}".format(self.language, self.extension)
         return filename
 
     @property


### PR DESCRIPTION
The current subtitle naming is note widely supported so I changed it to generally more approved way by using ´.´ instead of ´-´

See example for proper subtitle naming for ie plex:

https://support.plex.tv/articles/200471133-adding-local-subtitles-to-your-media/

most pc video players accept either way, so its more QOL change