### PR TITLE
smaller fixes / changes

### DIFF
--- a/udemy/_extract.py
+++ b/udemy/_extract.py
@@ -544,6 +544,8 @@ class Udemy(ProgressBar):
                                 sources     = data.get('sources')
                                 tracks      = data.get('tracks') if isinstance(data.get('tracks'), list) else subs
                                 duration    = data.get('duration')
+                                subtitles   = self._extract_subtitles(tracks)
+                                sources     = self._extract_sources(sources)
                                 lectures.append({
                                     'lecture_index' :   lecture_index,
                                     'lectures_id' : lecture_id,
@@ -552,10 +554,10 @@ class Udemy(ProgressBar):
                                     'duration' : duration,
                                     'assets' : retVal,
                                     'assets_count' : len(retVal),
-                                    'sources' : self._extract_sources(sources),
-                                    'subtitles' : self._extract_subtitles(tracks),
-                                    'subtitle_count' : len(self._extract_subtitles(tracks)),
-                                    'sources_count' : len(self._extract_sources(sources)),
+                                    'sources' : sources,
+                                    'subtitles' : subtitles,
+                                    'subtitle_count' : len(subtitles),
+                                    'sources_count' : len(sources),
                                     })
                             else:
                                 lectures.append({
@@ -582,6 +584,8 @@ class Udemy(ProgressBar):
                                 sources     = data.get('Video')
                                 tracks      = asset.get('captions')
                                 duration    = asset.get('time_estimation')
+                                subtitles   = self._extract_subtitles(tracks)
+                                sources     = self._extract_sources(sources)
                                 lectures.append({
                                     'lecture_index' :   lecture_index,
                                     'lectures_id' : lecture_id,
@@ -590,10 +594,10 @@ class Udemy(ProgressBar):
                                     'duration' : duration,
                                     'assets' : retVal,
                                     'assets_count' : len(retVal),
-                                    'sources' : self._extract_sources(sources),
-                                    'subtitles' : self._extract_subtitles(tracks),
-                                    'subtitle_count' : len(self._extract_subtitles(tracks)),
-                                    'sources_count' : len(self._extract_sources(sources)),
+                                    'sources' : sources,
+                                    'subtitles' : subtitles,
+                                    'subtitle_count' : len(subtitles),
+                                    'sources_count' : len(sources),
                                     })
                             else:
                                 lectures.append({

--- a/udemy/_sanitize.py
+++ b/udemy/_sanitize.py
@@ -60,6 +60,8 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False, space_rep
 
     """
 
+    s = re.sub('&', 'and', s)
+
     if only_ascii and ok != SLUG_OK and hasattr(ok, 'decode'):
         try:
             ok.decode('ascii')
@@ -84,6 +86,8 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False, space_rep
         new = re.sub('[%s\s]+' % space_replacement, space_replacement, new)
     if lower:
         new = new.lower()
+
+    new = re.sub('\s+', ' ', new)
 
     return new
 


### PR DESCRIPTION
slugify to replace "&" with "and" before cleaning up:  
`Tips & Tricks` will now become `Tips and Tricks` and not just `Tips  Tricks`  

slugify to replace double-space with single-space after cleaning:
sometimes after replacing a symbol/char between words, text might be like `Tips  Tricks` as only the symbol is remove, now remove double space in case it happens again (not with `&` at least)

change to avoid calling `_extract_subtitles()` / `_extract_sources()` multiple times